### PR TITLE
docs: Fix simple typo, calback -> callback

### DIFF
--- a/test/FieldVal_test.js
+++ b/test/FieldVal_test.js
@@ -541,7 +541,7 @@ describe('FieldVal', function() {
                         assert.strictEqual(emitted,undefined);
                     },
                 },
-                function(response){//calback
+                function(response){//callback
                     assert.strictEqual(null, response);
                     did_respond = true;
                 }
@@ -593,7 +593,7 @@ describe('FieldVal', function() {
                         assert.strictEqual(emitted,undefined);
                     },
                 },
-                function(response){//calback
+                function(response){//callback
                     assert.strictEqual(null, response);
                     did_respond++;
                 }
@@ -621,7 +621,7 @@ describe('FieldVal', function() {
                         assert.strictEqual(emitted,undefined);
                     },
                 },
-                function(response){//calback
+                function(response){//callback
                     assert.strictEqual(null, response);
                     did_respond++;
                 }


### PR DESCRIPTION
There is a small typo in test/FieldVal_test.js.

Should read `callback` rather than `calback`.

